### PR TITLE
replace tag. mentions for new SRG version

### DIFF
--- a/cli/src/SRGAutomation/evaluate/SRGEvaluate.ts
+++ b/cli/src/SRGAutomation/evaluate/SRGEvaluate.ts
@@ -79,9 +79,9 @@ class SRGEvaluate {
     );
     throw new Error(
       "Failed to find evaluation result for service " +
-        event["tag.service"] +
+        event["service"] +
         "in stage " +
-        event["tag.stage"] +
+        event["stage"] +
         " after 60 seconds. Check your configuration."
     );
   }

--- a/cli/src/SRGAutomation/evaluate/SRGEvaluationEvent.test.ts
+++ b/cli/src/SRGAutomation/evaluate/SRGEvaluationEvent.test.ts
@@ -34,29 +34,29 @@ describe("Evaluation event init", () => {
     });
     expect(event["timeframe.to"]).toBe(endTime);
   });
-  it("should set tag.service to the service name", () => {
+  it("should set service to the service name", () => {
     const event = new SRGEvaluationEvent({
       startTime: startTime,
       endTime: endTime,
       service: "demoservice"
     });
-    expect(event["tag.service"]).toBe("demoservice");
+    expect(event["service"]).toBe("demoservice");
   });
-  it("should set tag.application to the application name", () => {
+  it("should set application to the application name", () => {
     const event = new SRGEvaluationEvent({
       startTime: startTime,
       endTime: endTime,
       application: "test"
     });
-    expect(event["tag.application"]).toBe("test");
+    expect(event["application"]).toBe("test");
   });
-  it("should set tag.stage to the stage name", () => {
+  it("should set stage to the stage name", () => {
     const event = new SRGEvaluationEvent({
       startTime: startTime,
       endTime: endTime,
       stage: "test-stage"
     });
-    expect(event["tag.stage"]).toBe("test-stage");
+    expect(event["stage"]).toBe("test-stage");
   });
   it("should set event.provider to the provider name", () => {
     const event = new SRGEvaluationEvent({

--- a/cli/src/SRGAutomation/evaluate/SRGEvaluationEvent.ts
+++ b/cli/src/SRGAutomation/evaluate/SRGEvaluationEvent.ts
@@ -7,11 +7,11 @@ class SRGEvaluationEvent {
 
   "execution_context": ExecutionContext;
 
-  "tag.service": string;
+  "service": string;
 
-  "tag.application": string;
+  "application": string;
 
-  "tag.stage": string;
+  "stage": string;
 
   "event.id": string;
 
@@ -34,9 +34,9 @@ class SRGEvaluationEvent {
       options["buildId"],
       options["releaseVersion"]
     );
-    this["tag.service"] = options["service"];
-    this["tag.application"] = options["application"];
-    this["tag.stage"] = options["stage"];
+    this["service"] = options["service"];
+    this["application"] = options["application"];
+    this["stage"] = options["stage"];
     this["event.id"] = eventId;
     this["event.provider"] = options["provider"];
     this["event.type"] = "guardian.validation.triggered";

--- a/docs/Site-Reliability-Guardian/SRGAutomation-initial-setup.md
+++ b/docs/Site-Reliability-Guardian/SRGAutomation-initial-setup.md
@@ -85,10 +85,10 @@ Create a **Dynatrace Workflow** that includes the Site Reliability Guardian appl
 Then modify the Event trigger to follow this expression:
 
 ```
-event.type == "guardian.validation.triggered" AND tag.service == "your-service-name" AND tag.stage == "you-stage-name"
+event.type == "guardian.validation.triggered" AND service == "your-service-name" AND stage == "you-stage-name"
 ```
 
-> Note: The values for `tag.service` and `tag.stage` will be used as parameters during the CLI execution.
+> Note: The values for `service` and `stage` will be used as parameters during the CLI execution.
 
 <img src="./assets/workflow-filter.png"  width="675" height="350">
 

--- a/docs/Site-Reliability-Guardian/SRGAutomation.md
+++ b/docs/Site-Reliability-Guardian/SRGAutomation.md
@@ -14,7 +14,7 @@ The `dta srg evaluate` allows to automate the process of executing Site Reliabil
 The command `dta srg evaluate --service "your-service-name" --stage "stage-name"` triggers the following process:
 
 1. A Biz Event is sent into Dynatrace with the required details for the quality gate evaluation including start time, end time and service/stage name.
-2. On the Dynatrace side, a Dynatrace Workflow is already configured and is listening for the Biz Event payload based on the expression `event.type == "guardian.validation.triggered" AND tag.service == "your-service-name" AND tag.stage == "you-stage-name"`
+2. On the Dynatrace side, a Dynatrace Workflow is already configured and is listening for the Biz Event payload based on the expression `event.type == "guardian.validation.triggered" AND service == "your-service-name" AND stage == "you-stage-name"`
 3. The Dynatrace Workflow triggers the Site Reliability Guardian evaluation and sends the input parameters from the biz event into the SRG evaluation.
 4. The evaluation is executed, and a Biz Event is created by the SRG application with the evaluation results and the metadata that allows the CLI to query for this specific result.
 5. The CLI queries Dynatrace API for the Biz Event that matches an internal ID that was sent on step 1. By default, it will retry this query every 5 seconds for 12 times until it finds the result event. If the number of retries is exceeded an no event is present, the CLI will assume the configuration is broken and the execution will fail.


### PR DESCRIPTION
This will update the tag.service and tag.stage requirement to be compatible with the latest SRG that generates a workflow that looks for `stage` and `service` without the `tag` prefix