### PR TITLE
commander options declaration updated

### DIFF
--- a/cli/integration_tests/SRGCommand.integration.test.ts
+++ b/cli/integration_tests/SRGCommand.integration.test.ts
@@ -1,0 +1,183 @@
+import { Command } from "commander";
+import SRGCommand from "../src/SRGAutomation/SRGCommand";
+
+describe("SRGCommand required and mandatory options management", () => {
+  it("SRGCommand fails if stage option is missing", async () => {
+    const program = new Command();
+    program.name("Test program").exitOverride();
+    new SRGCommand(program);
+
+    await expect(
+      program.parseAsync(["", "", "srg", "evaluate", "--service", "any"])
+    ).rejects.toThrow("error: required option '--stage <stage>' not specified");
+  });
+
+  it("SRGCommand fails if service option is missing the argument", async () => {
+    const program = new Command();
+    program.name("Test program").exitOverride();
+    new SRGCommand(program);
+
+    await expect(
+      program.parseAsync(["", "", "srg", "evaluate", "--stage", "any"])
+    ).rejects.toThrow(
+      "error: required option '--service <service>' not specified"
+    );
+  });
+
+  it("SRGCommand fails if stage option is missing the argument", async () => {
+    const program = new Command();
+    program.name("Test program").exitOverride();
+    new SRGCommand(program);
+
+    await expect(
+      program.parseAsync([
+        "",
+        "",
+        "srg",
+        "evaluate",
+        "--service",
+        "any",
+        "--stage"
+      ])
+    ).rejects.toThrow("error: option '--stage <stage>' argument missing");
+  });
+
+  it("SRGCommand fails if service option is missing the argument", async () => {
+    const program = new Command();
+    program.name("Test program").exitOverride();
+    new SRGCommand(program);
+
+    await expect(
+      program.parseAsync([
+        "",
+        "",
+        "srg",
+        "evaluate",
+        "--stage",
+        "any",
+        "--service"
+      ])
+    ).rejects.toThrow("error: option '--service <service>' argument missing");
+  });
+
+  it("SRGCommand fails if start-time option is missing the argument", async () => {
+    const program = new Command();
+    program.name("Test program").exitOverride();
+    new SRGCommand(program);
+
+    await expect(
+      program.parseAsync([
+        "",
+        "",
+        "srg",
+        "evaluate",
+        "--stage",
+        "any",
+        "--service",
+        "any",
+        "--start-time"
+      ])
+    ).rejects.toThrow(
+      "error: option '--start-time <starttime>' argument missing"
+    );
+  });
+  it("SRGCommand fails if end-time option is missing the argument", async () => {
+    const program = new Command();
+    program.name("Test program").exitOverride();
+    new SRGCommand(program);
+
+    await expect(
+      program.parseAsync([
+        "",
+        "",
+        "srg",
+        "evaluate",
+        "--stage",
+        "any",
+        "--service",
+        "any",
+        "--end-time"
+      ])
+    ).rejects.toThrow("error: option '--end-time <endtime>' argument missing");
+  });
+  it("SRGCommand fails if application option is missing the argument", async () => {
+    const program = new Command();
+    program.name("Test program").exitOverride();
+    new SRGCommand(program);
+
+    await expect(
+      program.parseAsync([
+        "",
+        "",
+        "srg",
+        "evaluate",
+        "--stage",
+        "any",
+        "--service",
+        "any",
+        "--application"
+      ])
+    ).rejects.toThrow(
+      "error: option '--application <application>' argument missing"
+    );
+  });
+  it("SRGCommand fails if provider option is missing the argument", async () => {
+    const program = new Command();
+    program.name("Test program").exitOverride();
+    new SRGCommand(program);
+
+    await expect(
+      program.parseAsync([
+        "",
+        "",
+        "srg",
+        "evaluate",
+        "--stage",
+        "any",
+        "--service",
+        "any",
+        "--provider"
+      ])
+    ).rejects.toThrow("error: option '--provider <provider>' argument missing");
+  });
+  it("SRGCommand fails if release-version option is missing the argument", async () => {
+    const program = new Command();
+    program.name("Test program").exitOverride();
+    new SRGCommand(program);
+
+    await expect(
+      program.parseAsync([
+        "",
+        "",
+        "srg",
+        "evaluate",
+        "--stage",
+        "any",
+        "--service",
+        "any",
+        "--release-version"
+      ])
+    ).rejects.toThrow(
+      "error: option '--release-version <releaseVersion>' argument missing"
+    );
+  });
+  it("SRGCommand fails if buildId option is missing the argument", async () => {
+    const program = new Command();
+    program.name("Test program").exitOverride();
+    new SRGCommand(program);
+
+    await expect(
+      program.parseAsync([
+        "",
+        "",
+        "srg",
+        "evaluate",
+        "--stage",
+        "any",
+        "--service",
+        "any",
+        "--buildId"
+      ])
+    ).rejects.toThrow("error: option '--buildId <buildId>' argument missing");
+  });
+});

--- a/cli/src/SRGAutomation/evaluate/SRGCommandEvaluate.ts
+++ b/cli/src/SRGAutomation/evaluate/SRGCommandEvaluate.ts
@@ -77,12 +77,12 @@ class SRGCommandEvaluate implements BaseCommand {
   getTimeframeOptions(): Option[] {
     const options: Option[] = [];
     const startTime = new Option(
-      "--start-time [starttime]",
+      "--start-time <starttime>",
       "Evaluation start time"
     )
       .conflicts("timespan")
       .env("SRG_EVALUATION_START_TIME");
-    const endTime = new Option("--end-time [endtime]", "Evaluation end time")
+    const endTime = new Option("--end-time <endtime>", "Evaluation end time")
       .conflicts("timespan")
       .env("SRG_EVALUATION_END_TIME");
     const timeSpan = new Option(
@@ -101,39 +101,39 @@ class SRGCommandEvaluate implements BaseCommand {
   getDescriptionOptions(): Option[] {
     const options: Option[] = [];
     const application = new Option(
-      "--application [application]",
+      "--application <application>",
       "Application name"
     )
       .default("")
       .env("SRG_EVALUATION_APPLICATION");
     const service = new Option(
-      "--service [service]",
+      "--service <service>",
       "Service name. i.e. backend-service, api-gateway, etc."
     )
       .env("SRG_EVALUATION_SERVICE")
       .makeOptionMandatory(true);
 
     const stage = new Option(
-      "--stage [stage]",
+      "--stage <stage>",
       "Evaluation stage, can be dev, test,quality-gate, prod, etc."
     )
       .env("SRG_EVALUATION_STAGE")
       .makeOptionMandatory(true);
 
     const provider = new Option(
-      "--provider [provider]",
+      "--provider <provider>",
       "Provider of the request. i.e. github, jenkins, jenkins-production-1 etc."
     )
       .default("cicd")
       .env("SRG_EVALUATION_PROVIDER");
     const version = new Option(
-      "--release-version [releaseVersion]",
+      "--release-version <releaseVersion>",
       "Version of the app. for example v1.0.1"
     )
       .default("")
       .env("SRG_EVALUATION_VERSION");
     const buildId = new Option(
-      "--buildId [buildId]",
+      "--buildId <buildId>",
       "Build ID. optional for reference in the evaluation. Can also be used for the Git commit ID"
     )
       .default("")


### PR DESCRIPTION
In [commander.js](https://www.npmjs.com/package/commander/v/5.1.0#specify-the-argument-syntax), angled brackets (e.g., <required>) indicate required input, while square brackets (e.g., [optional]) indicate optional input.
The current commander configuration allows the stage and service options to be passed without arguments. It has been updated to throw an error when options that seem to require arguments are passed without them.